### PR TITLE
add getParentNodeCollection() to Node interface

### DIFF
--- a/ditto/src/main/java/eu/xenit/testing/ditto/api/model/Node.java
+++ b/ditto/src/main/java/eu/xenit/testing/ditto/api/model/Node.java
@@ -36,6 +36,7 @@ public interface Node {
     }
 
     ParentChildNodeCollection getChildNodeCollection();
+    ParentChildNodeCollection getParentNodeCollection();
 
     interface Filters {
         static <T> Predicate<T> always(boolean value) {

--- a/ditto/src/main/java/eu/xenit/testing/ditto/internal/DefaultNode.java
+++ b/ditto/src/main/java/eu/xenit/testing/ditto/internal/DefaultNode.java
@@ -20,6 +20,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -69,6 +70,9 @@ public class DefaultNode implements Node {
     private final DefaultParentChildNodeCollection childNodeCollection;
 
     @Getter
+    private final DefaultParentChildNodeCollection parentNodeCollection;
+
+    @Getter
     private final Set<QName> aspects;
 
     private static NodeInitializer init = new NodeInitializer();
@@ -86,8 +90,11 @@ public class DefaultNode implements Node {
         if (builder.context.getParent() != null && builder.context.getParentChildAssocType() != null) {
             this.primaryParentAssoc = new DefaultParentChildAssoc(builder.context.getParent(),
                     builder.context.getParentChildAssocType(), this, true);
+            this.parentNodeCollection = new DefaultParentChildNodeCollection(primaryParentAssoc.getParent(),
+                    Collections.singletonList(primaryParentAssoc));
         } else {
             this.primaryParentAssoc = null;
+            this.parentNodeCollection = null;
         }
 
         init.accept(this, builder.context);

--- a/ditto/src/test/java/eu/xenit/testing/ditto/internal/DefaultNodeTest.java
+++ b/ditto/src/test/java/eu/xenit/testing/ditto/internal/DefaultNodeTest.java
@@ -4,12 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import eu.xenit.testing.ditto.api.AlfrescoDataSet;
 import eu.xenit.testing.ditto.api.data.ContentModel.Content;
 import eu.xenit.testing.ditto.api.model.MLText;
 import eu.xenit.testing.ditto.api.model.Node;
+import eu.xenit.testing.ditto.api.model.ParentChildNodeCollection;
 import eu.xenit.testing.ditto.internal.DefaultTransaction.TransactionContext;
 import java.time.Instant;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class DefaultNodeTest {
@@ -56,5 +60,44 @@ class DefaultNodeTest {
         assertThat(node.getProperties().get(Content.NAME)).hasValue(name);
 
     }
+
+    @Test
+    void parentAssocsSingle() {
+        final Node[] parents = new Node[1];
+        final String[] noderefs = new String[1];
+
+        AlfrescoDataSet dataSet = AlfrescoDataSet
+                .bootstrapAlfresco(Instant.now())
+                .skipToTransaction(123L)
+                .addTransaction(txn -> {
+                    parents[0] = txn.addNode(doc -> {
+                        doc.type(Content.FOLDER);
+                        doc.name("foo");
+                        doc.property("cm:description", "Folder description");
+                    });
+                })
+                .skipToTransaction(456L)
+                .addTransaction((txn -> {
+                    txn.addNode(parents[0], doc -> {
+                        doc.type(Content.CONTENT);
+                        doc.name("bar.txt");
+                        doc.content("bar");
+                        doc.property("cm:description", "Document description");
+                        noderefs[0] = doc.nodeRef().toString();
+                    });
+                }))
+                .build();
+        Optional<Node> node1 = dataSet.getNodeView().getNode(noderefs[0]);
+        assertThat(node1).isPresent().hasValueSatisfying(value -> {
+            assertThat(value).isInstanceOf(Node.class)
+                    .satisfies(node -> {
+                        ParentChildNodeCollection parentNodeCollection = node.getParentNodeCollection();
+                        assertThat(parentNodeCollection.getAssociations().count()).isEqualTo(1);
+                        assertThat(parentNodeCollection.getAssociations().collect(Collectors.toList())
+                                .get(0).getParent()).isEqualTo(parents[0]);
+                    });
+        });
+    }
+
 
 }


### PR DESCRIPTION
no test for multiple parent assocs yet
I don't see an easy way to add additional assocs apart from primary parent to a test dataset for now