### PR TITLE
Deprecate named-references from NodeCustomizer, RootContext, TransactionContext, ...

### DIFF
--- a/ditto/src/main/java/eu/xenit/testing/ditto/api/AlfrescoDataSet.java
+++ b/ditto/src/main/java/eu/xenit/testing/ditto/api/AlfrescoDataSet.java
@@ -1,6 +1,5 @@
 package eu.xenit.testing.ditto.api;
 
-import eu.xenit.testing.ditto.api.data.ContentModel.System;
 import eu.xenit.testing.ditto.api.model.Node;
 import java.time.Instant;
 import java.util.function.Consumer;
@@ -50,6 +49,7 @@ public interface AlfrescoDataSet {
         return builder().build();
     }
 
+    @Deprecated
     Node getNamedReference(String name);
 
     TransactionView getTransactionView();

--- a/ditto/src/main/java/eu/xenit/testing/ditto/api/NodeCustomizer.java
+++ b/ditto/src/main/java/eu/xenit/testing/ditto/api/NodeCustomizer.java
@@ -45,7 +45,10 @@ public interface NodeCustomizer {
 
     NodeCustomizer callback(Consumer<Node> callback);
 
+    @Deprecated
     NodeCustomizer createNamedReference(String name);
+
+    @Deprecated
     NodeCustomizer createNamedReference();
 
     String storeRefProtocol();

--- a/ditto/src/main/java/eu/xenit/testing/ditto/internal/DefaultNode.java
+++ b/ditto/src/main/java/eu/xenit/testing/ditto/internal/DefaultNode.java
@@ -182,6 +182,7 @@ public class DefaultNode implements Node {
         }
 
 
+        @Deprecated
         void createNamedReference(String name, Node node) {
             this.txnContext.createNamedReference(name, node);
         }
@@ -501,11 +502,13 @@ public class DefaultNode implements Node {
         }
 
         @Override
+        @Deprecated
         public NodeBuilder createNamedReference(String name) {
             return this.callback(node -> this.context.createNamedReference(name, node));
         }
 
         @Override
+        @Deprecated
         public NodeBuilder createNamedReference() {
             return this.callback(node -> this.context.createNamedReference(node.getName(), node));
         }

--- a/ditto/src/main/java/eu/xenit/testing/ditto/internal/NodeInitializer.java
+++ b/ditto/src/main/java/eu/xenit/testing/ditto/internal/NodeInitializer.java
@@ -38,6 +38,7 @@ public class NodeInitializer {
         this.setupBiDrectionalPeerAssocs(node);
     }
 
+    // FIXME the child collections should NOT be mutable through their public API !!
     private void setupBiDirectionalParentAssoc(DefaultNode node) {
         ParentChildAssoc parentAssoc = node.getPrimaryParentAssoc();
         if (parentAssoc == null) {


### PR DESCRIPTION
named-references need to go away when working towards a write-enabled ditto API